### PR TITLE
Fixed Grey Goo Destroying Multiworld Civilizations

### DIFF
--- a/src/epitaph/techs.cljs
+++ b/src/epitaph/techs.cljs
@@ -301,6 +301,7 @@
     :prereqs #{:nanotechnology :networked-computers :spaceflight}
     :event-chances {:asteroid -1
                     :volcano -1
+                    :gray-goo -1
                     :world-government (/ +2 90)}
     :desc ["The $CIV have begun to establish permanent colonies on worlds "
            "other than $PLANET. Although still largely unable to travel "


### PR DESCRIPTION
Prevent grey goo from destroying multiworld civilizations.

Fixes #3

A separate event for Von Neumann probes (unmanned interstellar probes) becoming grey goo would be interesting though. Even more so if it could create an event that can then wipe out other civilizations, or even an actual TOTAL game over as it spread to the whole galaxy slowly (or fast if it has FTL).